### PR TITLE
Remove extra heading and clean up typos in agile-development subsection

### DIFF
--- a/content/docs/agile-development/planning-and-prioritization/index.md
+++ b/content/docs/agile-development/planning-and-prioritization/index.md
@@ -13,11 +13,9 @@ toc = true
 top = false
 +++
 
-## Planning & Prioritization
-
 Given that we don't do Scrum. We don't really do formal "sprint planning". In fact we don't actually believe in the constraint of a "sprint".
 
-Instead we "roadmap planning" and lose "iteration planning". The destinction is that we do plan for an iteration (roughly a week or two out). However that planning simply funnels into the Kanban board as to what we are targeting working on. If that changes as more information comes in it isn't a problem as we are just working down through the prioritized columns. This differs from the concept of formal sprints where a sprint's tickets are usually locked in until the following sprint.
+Instead we focus on "roadmap planning" and "iteration planning". The destinction is that we do plan for an iteration (roughly a week or two out). However that planning simply funnels into the Kanban board as to what we are targeting working on. If that changes as more information comes in it isn't a problem as we are just working down through the prioritized columns. This differs from the concept of formal sprints where a sprint's tickets are usually locked in until the following sprint.
 
 We have a **weekly** Planning & Prioritization meetings.
 


### PR DESCRIPTION
The intention of this change is to standardize this page with the others
by removing the extra title header. Also cleared up the statement of
what sorts of planning we do, so that the comparison between that and
what 'sprint planning' is can be more easily understood.

The reason for making these changes is to maintain page standards and
succinct clear description of our agile methodologies.

ps-id: 8BC2BA37-7644-4D41-9E40-2709ADEF8137