### PR TITLE
Add reference to Luxon library in Typescript resource

### DIFF
--- a/content/docs/resources/typescript/index.md
+++ b/content/docs/resources/typescript/index.md
@@ -1,0 +1,20 @@
++++
+title = "Typescript Resources"
+description = "A brief listing of useful Typescript resources"
+date = 2022-07-11T00:00:00+00:00
+updated = 2022-07-11T00:00:00+00:00
+draft = false
+weight = 333
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+toc = true
+top = false
++++
+
+## Date & Time
+
+* [Luxon][] ([@types](https://www.npmjs.com/package/@types/luxon)): Improves working with dates and times.
+
+[Luxon]: https://www.npmjs.com/package/luxon


### PR DESCRIPTION
I did this because `Luxon` is a great library for interacting with
dates, times and all the operations you often have to perform in web
applications and apis.

This adds a typescript resource page with a reference to the Luzon
library. Hopefully this helps people use Luxon instead of JS date

ps-id: 8AC8C072-45B0-415B-B164-46E2169F6155