### PR TITLE
[UE-31] Document canary grouping using typescript

### DIFF
--- a/content/docs/resources/feature-toggles/index.md
+++ b/content/docs/resources/feature-toggles/index.md
@@ -1,0 +1,34 @@
++++
+title = "Feature Flag Resources"
+description = "A brief listing of useful feature flag resources"
+date = 2023-01-18T20:33:00+00:00
+updated = 2023-01-18T20:33:00+00:00
+draft = false
+weight = 420
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+toc = true
+top = false
++++
+
+* "Growthbook" - [link](https://docs.growthbook.io/)
+
+### Canary Testing with Growthbook
+
+Our [Flutter Growthbook Wrapper](https://github.com/uptech/uptech-growthbook-sdk-flutter) makes it easy to do canary testing and version baselining with Growthbook
+
+In the Growthbook GUI:
+
+* Add wanted attributes (for the canary testing example, use id and set it as identifier) [link](https://docs.growthbook.io/app/features#targeting-attributes)
+
+* Add an override rule:
+`if id is in the list` (add desired tester ids)
+[link](https://docs.growthbook.io/app/features#override-rules)
+
+**Using the Uptech Growthbook Wrapper to set attributes**
+
+In Flutter: [link](https://github.com/uptech/uptech-growthbook-sdk-flutter#set-attributes)
+
+In Typescript: [link](https://github.com/uptech/uptech-growthbook-sdk-typescript#set-attributes)

--- a/content/docs/resources/flutter-resources/index.md
+++ b/content/docs/resources/flutter-resources/index.md
@@ -72,23 +72,6 @@ Our standard is to use DartDefine & Flavors in our Flutter apps. These allow us 
 ---
 Hopefully this helps explain the details behind `--flavor` and `--dart-define FLAVOR=dev`
 
-## Feature Flagging
-
-* "Growthbook" - [link](https://docs.growthbook.io/)
-
-### Canary Testing with Growthbook
-
-Our [Flutter Growthbook Wrapper](https://github.com/uptech/uptech-growthbook-sdk-flutter) makes it easy to do canary testing and version baselining with Growthbook
-
-In the Growthbook GUI:
-
-* Add wanted attributes (for the canary testing example, use id and set it as identifier) [link](https://docs.growthbook.io/app/features#targeting-attributes)
-
-* Add an override rule: `if id is in the list` (add desired tester ids) [link](https://docs.growthbook.io/app/features#override-rules)
-
-Using the Uptech Growthbook Wrapper to set attributes: [link] (https://github.com/uptech/uptech-growthbook-sdk-flutter#set-attributes)
-
-
 ## VS Code Extensions
 
 ### [Dart](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-codes)


### PR DESCRIPTION
The intention of this change is to more fully explain the
steps to do canary grouping using Growthbook. It is
documented in our engineering page because it documents
using the Growthbook GUI to set up override rules,
which was out of the scope for the Uptech Growthbook Wrapper docs.

While this used to be documented in the Flutter Resources,
the section has been moved to its own Feature Flag page.
This is to ensure that all information about Growthbook using
both our Typescript and Flutter wrapper are in the same place
and there is no duplicate copy

[changelog]
added: 'Feature Flagging Resources' section in Resources

<!-- ps-id: 2ee0f9d4-d49b-409b-aa57-cd21bf147435 -->